### PR TITLE
Group load balancer support

### DIFF
--- a/app.json
+++ b/app.json
@@ -459,6 +459,15 @@
               }
             }
           ]
+        },
+        {
+          "id": "loadBalanceType",
+          "type": "text",
+          "value": "EXTERNAL",
+          "label": {
+            "en": "Meter Load Balance Type",
+            "sv": "Meter Load Balance Type"
+          }
         }
       ],
       "id": "gnm3d-rs485"

--- a/drivers/gnm3d-rs485/device-const.ts
+++ b/drivers/gnm3d-rs485/device-const.ts
@@ -1,2 +1,3 @@
 export const baseUrl = 'servlet/rest/chargebox'; // Prefix with http://192.168.123:8080 device address
-export const meterInfoUrl = `${baseUrl}/meterinfo/EXTERNAL?_=`
+export const meterInfoUrl = `${baseUrl}/meterinfo/`
+export const configUrl = `${baseUrl}/config?_=`;

--- a/drivers/gnm3d-rs485/device.ts
+++ b/drivers/gnm3d-rs485/device.ts
@@ -1,7 +1,7 @@
 import Homey from 'homey';
 import fetch from "http.min";
 import { ExternalMeterStatus } from '../../types/external-meter-status';
-import { meterInfoUrl } from './device-const';
+import {baseUrl, meterInfoUrl} from './device-const';
 
 class SmartMeterDevice extends Homey.Device {
   currentStatus?: ExternalMeterStatus;
@@ -71,7 +71,7 @@ class SmartMeterDevice extends Homey.Device {
   async poll() {
     try {
       const result: ExternalMeterStatus = await fetch.json(
-        `http://${this.address}:8080/${meterInfoUrl}${new Date().getTime()}`
+        `http://${this.address}:8080/${this.getMeterInfoUrl()}${new Date().getTime()}`
       );
 
       const accEnergy = this.getCapabilityValue("meter_power");
@@ -125,6 +125,10 @@ class SmartMeterDevice extends Homey.Device {
     } catch (e: any) {
       this.error(e);
     }
+  }
+
+  private getMeterInfoUrl() {
+    return `${meterInfoUrl}${this.getSetting("loadBalanceType")}?_=`;
   }
 }
 

--- a/drivers/gnm3d-rs485/device.ts
+++ b/drivers/gnm3d-rs485/device.ts
@@ -1,7 +1,7 @@
 import Homey from 'homey';
 import fetch from "http.min";
 import { ExternalMeterStatus } from '../../types/external-meter-status';
-import {baseUrl, meterInfoUrl} from './device-const';
+import {meterInfoUrl} from './device-const';
 
 class SmartMeterDevice extends Homey.Device {
   currentStatus?: ExternalMeterStatus;

--- a/drivers/gnm3d-rs485/driver.compose.json
+++ b/drivers/gnm3d-rs485/driver.compose.json
@@ -68,6 +68,15 @@
           }
         }
       ]
+    },
+    {
+      "id": "loadBalanceType",
+      "type": "text",
+      "value": "EXTERNAL",
+      "label": {
+        "en": "Meter Load Balance Type",
+        "sv": "Meter Load Balance Type"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added support for meters that are configured as a groupLoadBalancer instead of localLoadBalancer on the Garo charger. Code checks from the Garo configs which type of load balancer is configured and adjusts the used url for the meter accordingly.